### PR TITLE
Add secure download path validation

### DIFF
--- a/tests/test_download_security.py
+++ b/tests/test_download_security.py
@@ -1,0 +1,46 @@
+import os
+from pathlib import Path
+import types
+import importlib
+import pytest
+
+from fastapi import HTTPException
+
+import utils.file_service as fs
+
+
+def setup_upload_dir(tmp_path, monkeypatch):
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    monkeypatch.setattr(fs, "UPLOADS_DIR", uploads)
+    return uploads
+
+
+def test_absolute_path_denied(tmp_path, monkeypatch):
+    setup_upload_dir(tmp_path, monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        fs.download_file("/etc/passwd")
+    assert exc.value.status_code == 400
+
+
+def test_outside_uploads_denied(tmp_path, monkeypatch):
+    setup_upload_dir(tmp_path, monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        fs.download_file("../secret.txt")
+    assert exc.value.status_code == 403
+
+
+def test_nonexistent_file(tmp_path, monkeypatch):
+    setup_upload_dir(tmp_path, monkeypatch)
+    with pytest.raises(HTTPException) as exc:
+        fs.download_file("missing.txt")
+    assert exc.value.status_code == 404
+
+
+def test_success(tmp_path, monkeypatch):
+    uploads = setup_upload_dir(tmp_path, monkeypatch)
+    file = uploads / "hello.txt"
+    file.write_text("ok")
+    resp = fs.download_file("hello.txt")
+    assert resp.path == str(file)
+    assert resp.filename == "hello.txt"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utility package

--- a/utils/file_service.py
+++ b/utils/file_service.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from fastapi import HTTPException
+from fastapi.responses import FileResponse
+
+# Base directory of the project (two levels up from this file)
+BASE_DIR = Path(__file__).resolve().parents[1]
+UPLOADS_DIR = BASE_DIR / "uploads"
+
+
+def download_file(path: str):
+    """Return FileResponse for files only inside ``UPLOADS_DIR``.
+
+    Absolute paths are forbidden and any attempt to access files
+    outside ``UPLOADS_DIR`` results in an error.
+    """
+    p = Path(path)
+
+    if p.is_absolute():
+        # absolute paths are not allowed
+        raise HTTPException(status_code=400, detail="Absolute path not allowed")
+
+    full_path = (UPLOADS_DIR / p).resolve()
+    uploads_root = UPLOADS_DIR.resolve()
+
+    if uploads_root not in full_path.parents and full_path != uploads_root:
+        # Trying to escape uploads directory
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if not full_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    return FileResponse(str(full_path), filename=full_path.name)


### PR DESCRIPTION
## Summary
- provide download helper in `utils/file_service` that forbids absolute paths and restricts access to `uploads`
- test security behaviour of `download_file`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685c5d8d14a0832ab60917d176ddb02d