### PR TITLE
Fix add_request_row to always update full range

### DIFF
--- a/sheets.py
+++ b/sheets.py
@@ -40,10 +40,14 @@ def add_request_row(data: dict) -> None:
         data.get('route', ''),
         data.get('cargo', ''),
         data.get('orig_price', ''),
-        '', '', '',
+        '',
+        '',
+        '',
         'Активна',
     ]
-    sheet.append_row(row)
+    # determine next empty row starting from column A
+    target = len(sheet.get_all_values()) + 1
+    sheet.update(f"A{target}:K{target}", [row])
 
 
 def update_request(request_id: int, updates: dict) -> None:


### PR DESCRIPTION
## Summary
- ensure new requests fill columns A–K at once via `sheet.update`
- adjust dummy sheet and tests for new behaviour
- verify rows are inserted on lines 2 and 3 with header row present

## Testing
- `pytest -q tests/test_sheets.py`

------
https://chatgpt.com/codex/tasks/task_e_685c630f9224832a8d562faf1785f0b9