### PR TITLE
Implement safe gspread credentials

### DIFF
--- a/main.py
+++ b/main.py
@@ -520,7 +520,9 @@ def extract_route(text: str) -> tuple[str, str] | None:
     to_city   = m.group(2).strip().title()
     return from_city, to_city
 
-from sheets import add_request_row as add_record, sheet
+from sheets import add_request_row as add_record, sheet, safe_gspread_client
+
+gspread_client = safe_gspread_client()
 from database import database, agents, orders
 from database import companies as company
 
@@ -1066,7 +1068,8 @@ async def close_order(request: CloseOrderRequest):
 
     # добавляем строку‑лог в таблицу
     try:
-        sheet.append_row([
+        if sheet:
+            sheet.append_row([
             datetime.now().strftime('%Y-%m-%d %H:%M:%S'),   # Дата/время
             executor_info["agent_type"],                    # тип
             executor_info["name"],                          # имя

--- a/sheets.py
+++ b/sheets.py
@@ -1,30 +1,47 @@
+import os
+import json
+
 import gspread
-from google.oauth2.service_account import Credentials
-import os, io, json
+from google.oauth2 import service_account
 
-key_path = os.getenv(
-    "GOOGLE_APPLICATION_CREDENTIALS",
-    os.path.join(os.path.dirname(__file__), "keys", "prod-sa.json"),
-)
-if not os.path.isfile(key_path):
-    raise RuntimeError(
-        "Service account key not found. "
-        "Set GOOGLE_APPLICATION_CREDENTIALS or place prod-sa.json"
+
+KEY_ENV = "GOOGLE_APPLICATION_CREDENTIALS"
+DEFAULT_KEY = os.path.join(os.path.dirname(__file__), "keys", "prod-sa.json")
+_warned = False
+
+
+def safe_gspread_client() -> "gspread.Client | None":
+    """Return authorized gspread client or ``None`` if key missing."""
+    global _warned
+    key_path = os.getenv(KEY_ENV, DEFAULT_KEY)
+    if not os.path.isfile(key_path):
+        if not _warned:
+            print(
+                f"\u26A0\ufe0f  Service-account json not found: {key_path}. "
+                "Google Sheets features disabled."
+            )
+            _warned = True
+        return None
+
+    scopes = [
+        "https://www.googleapis.com/auth/spreadsheets",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = service_account.Credentials.from_service_account_file(
+        key_path, scopes=scopes
     )
+    return gspread.authorize(creds)
 
-with io.open(key_path, "r", encoding="utf-8") as f:
-    sa_config = json.load(f)
-SPREADSHEET_ID = '1oZaOlgU9gX4IwAPaa_Cl2eXVKbLeSvSPtt0oAG4nKO0'
-SHEET_NAME = 'Заявки'
 
-SCOPES = [
-    'https://www.googleapis.com/auth/spreadsheets',
-    'https://www.googleapis.com/auth/drive'
-]
+SPREADSHEET_ID = "1oZaOlgU9gX4IwAPaa_Cl2eXVKbLeSvSPtt0oAG4nKO0"
+SHEET_NAME = "Заявки"
 
-creds = Credentials.from_service_account_info(sa_config, scopes=SCOPES)
-client = gspread.authorize(creds)
-sheet = client.open_by_key(SPREADSHEET_ID).worksheet(SHEET_NAME)
+gspread_client = safe_gspread_client()
+sheet = (
+    gspread_client.open_by_key(SPREADSHEET_ID).worksheet(SHEET_NAME)
+    if gspread_client
+    else None
+)
 
 COL_IDX = {
     'id': 1,
@@ -43,6 +60,8 @@ COL_IDX = {
 
 def add_request_row(data: dict) -> None:
     """Append new request row to the Google Sheet."""
+    if sheet is None:
+        return
     row = [
         data.get('id', ''),
         data.get('date', ''),
@@ -63,6 +82,8 @@ def add_request_row(data: dict) -> None:
 
 def update_request(request_id: int, updates: dict) -> None:
     """Update selected columns for a request found by its ID."""
+    if sheet is None:
+        return
     rows = sheet.get_all_values()
     target = None
     for idx, r in enumerate(rows, start=1):

--- a/tests/gspread_stub.py
+++ b/tests/gspread_stub.py
@@ -1,0 +1,35 @@
+class DummySheet:
+    def __init__(self):
+        self.rows = []
+
+    def append_row(self, row):
+        self.rows.append(list(row))
+
+    def get_all_values(self):
+        return [list(map(str, r)) for r in self.rows]
+
+    def update_cell(self, row, col, value):
+        while len(self.rows) < row:
+            self.rows.append([""] * max(col, 1))
+        if len(self.rows[row - 1]) < col:
+            self.rows[row - 1].extend([""] * (col - len(self.rows[row - 1])))
+        self.rows[row - 1][col - 1] = value
+
+    def update(self, rng, values):
+        row = int(rng.split(":")[0][1:])
+        while len(self.rows) < row:
+            self.rows.append([""] * len(values[0]))
+        self.rows[row - 1] = list(values[0])
+
+
+class Client:
+    def __init__(self, sheet=None):
+        self.sheet = sheet or DummySheet()
+
+    def open_by_key(self, key):
+        return type("Obj", (), {"worksheet": lambda self2, name: self.sheet})()
+
+
+def authorize(_):
+    return Client()
+


### PR DESCRIPTION
## Summary
- add a helper `safe_gspread_client` in `sheets.py`
- initialize the sheet only when credentials exist
- guard calls to Google Sheets from `main.py`
- expose a basic gspread stub for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e47147a64832a91d9a1b58da6d76d